### PR TITLE
Fixed the url of POI icon

### DIFF
--- a/src/pages/positioning/positioning.ts
+++ b/src/pages/positioning/positioning.ts
@@ -209,7 +209,7 @@ export class PositioningPage {
           width: 35
         }
       }
-      if (poi.category) icon.url = poi.category.icon_selected;
+      if (poi.category) icon.url = `https://dashboard.situm.es${poi.category.icon_selected}`;
 
       let markerOptions: MarkerOptions = {
         icon: icon,


### PR DESCRIPTION
The URLs of POI icons were not complete, so I added prefix of `https://dashboard.situm.es`